### PR TITLE
Use async_trait crate to implement trait with async functions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "byteorder_async"
-version = "1.1.0"  #:version
+version = "1.2.0"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>", "Sam M."]
 description = "Library for reading/writing numbers in big-endian and little-endian asynchronously."
 documentation = "https://docs.rs/byteorder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "byteorder_async"
-version = "1.2.0"  #:version
+version = "1.3.0"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>", "Sam M."]
 description = "Library for reading/writing numbers in big-endian and little-endian asynchronously."
 documentation = "https://docs.rs/byteorder"
@@ -21,7 +21,7 @@ bench = false
 [dependencies]
 tokio = {version="0.2.18", features=["io-util"], optional = true }
 futures = { version = "0.3.4", optional = true }
-
+async-trait = "0.1.38"
 
 [dev-dependencies]
 quickcheck = { version = "0.8", default-features = false }

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ This is a fork of [byteorder](https://github.com/BurntSushi/byteorder) with the 
 
 for `futures::io`
 ```toml
-byteorder_async = {version="1.1.0", features=["futures_async"] }
+byteorder_async = {version="1.2.0", features=["futures_async"] }
 ```
 
 
 for `tokio::io`
 ```toml
-byteorder_async = {version="1.1.0", features=["tokio_async"] }
+byteorder_async = {version="1.2.0", features=["tokio_async"] }
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -13,27 +13,22 @@ This is a fork of [byteorder](https://github.com/BurntSushi/byteorder) with the 
 
 for `futures::io`
 ```toml
-byteorder_async = {version="1.2.0", features=["futures_async"] }
+byteorder_async = {version="1.3.0", features=["futures_async"] }
 ```
 
 
 for `tokio::io`
 ```toml
-byteorder_async = {version="1.2.0", features=["tokio_async"] }
+byteorder_async = {version="1.3.0", features=["tokio_async"] }
 ```
 
 
 Basic async usage:
 
 ```rust
-use byteorder_async::ReaderToByteOrder;
+use byteorder_async::AsyncReadByteOrder;
 
 let reader : io::AsyncRead = ...;
 // after the byte_order its the same calls.
-let byte = reader.byte_order().read_u8().await;
+let byte = reader.read_u8().await;
 ```
-
-
-
-Note:
-Thre reason for the `byte_order()` call is because `async fn` is not supprted in traits yet. 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,9 +75,6 @@ cases.
 #[cfg(feature = "std")]
 extern crate core;
 
-#[cfg(feature = "tokio")]
-extern crate tokio;
-
 use core::fmt::Debug;
 use core::hash::Hash;
 use core::ptr::copy_nonoverlapping;
@@ -89,12 +86,10 @@ pub use io::{ReadBytesExt, WriteBytesExt};
 #[cfg(feature = "std")]
 mod io;
 
-#[cfg(feature = "futures")]
-#[cfg(feature = "tokio")]
+#[cfg(any(feature = "tokio_async", feature = "futures_async"))]
 mod async_io;
 
-#[cfg(feature = "tokio")]
-#[cfg(feature = "futures")]
+#[cfg(any(feature = "tokio_async", feature = "futures_async"))]
 pub use async_io::{ReaderToByteOrder, WriterToByteOrder};
 
 #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ mod io;
 mod async_io;
 
 #[cfg(any(feature = "tokio_async", feature = "futures_async"))]
-pub use async_io::{ReaderToByteOrder, WriterToByteOrder};
+pub use async_io::{AsyncReadByteOrder, AsyncWriteByteOrder};
 
 #[inline]
 fn extend_sign(val: u64, nbytes: usize) -> i64 {


### PR DESCRIPTION
With the async_trait macro from the [async_trait](https://github.com/dtolnay/async-trait) crate there is no need for the byte_order() call, making the usage more in line with the original byteorder crate.